### PR TITLE
Add minimal usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ cabal install .
 
 4. Run `dot-analysis` -
     ```
-    dot-analysis {agda_file_name}.agda
+    dot-analysis {file_name}.dot
     ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # dot-analysis
+
 Analysing dependency graphs produced by Agda
+
+## Installation
+
+```
+cabal install .
+```
+
+## Quick usage
+
+1. Install [agda](https://agda.readthedocs.io/en/latest/getting-started/installation.html).
+
+2. Install [graphviz](https://graphviz.org/download/).
+
+3. Generate a `dot` file for an `agda` file -
+    ```
+    agda -i. --dependency-graph={file_name}.dot {agda_file_name}.agda`
+    ```
+
+4. Run `dot-analysis` -
+    ```
+    dot-analysis {agda_file_name}.agda
+    ```

--- a/dot-analysis.cabal
+++ b/dot-analysis.cabal
@@ -19,7 +19,7 @@ maintainer:         guillaume.allais@ens-lyon.org
 -- A copyright notice.
 -- copyright:
 -- category:
-extra-source-files: CHANGELOG.md
+-- extra-source-files: CHANGELOG.md
 
 executable dot-analysis
     main-is:          Main.hs

--- a/dot-analysis.cabal
+++ b/dot-analysis.cabal
@@ -19,7 +19,6 @@ maintainer:         guillaume.allais@ens-lyon.org
 -- A copyright notice.
 -- copyright:
 -- category:
--- extra-source-files: CHANGELOG.md
 
 executable dot-analysis
     main-is:          Main.hs


### PR DESCRIPTION
Following up on https://github.com/gallais/dot-analysis/issues/1#issuecomment-1612012487, I've added very minimal instructions for installing and using `dot-analysis`.